### PR TITLE
feat: scaffold nuxt flowbite base

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,20 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>
+
+<script setup lang="ts">
+useHead({
+  htmlAttrs: {
+    'data-tenant': 'acme',
+    'data-theme': undefined
+  },
+  style: [
+    {
+      id: 'tenant-tokens',
+      children: ''
+    }
+  ]
+})
+</script>

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,14 +1,6 @@
-// https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  compatibilityDate: '2025-07-15',
-  devtools: { enabled: true },
-
-  modules: [
-    '@nuxt/content',
-    '@nuxt/eslint',
-    '@nuxt/image',
-    '@nuxt/scripts',
-    '@nuxt/test-utils',
-    '@nuxt/ui'
-  ]
+  ssr: true,
+  css: ['~/assets/css/tailwind.css'],
+  build: { transpile: ['flowbite-vue'] },
+  vite: { ssr: { noExternal: ['flowbite-vue'] } }
 })

--- a/package.json
+++ b/package.json
@@ -1,35 +1,20 @@
 {
-  "name": "nuxt-app",
-  "type": "module",
+  "name": "poc-nuxt-flowbite-tokens-2",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "nuxt build",
     "dev": "nuxt dev",
-    "generate": "nuxt generate",
-    "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "build": "nuxt build",
+    "start": "nuxt start"
   },
   "dependencies": {
-    "@googlemaps/markerclusterer": "^2.6.2",
-    "@nuxt/content": "3.7.1",
-    "@nuxt/eslint": "1.9.0",
-    "@nuxt/image": "1.11.0",
-    "@nuxt/scripts": "0.12.1",
-    "@nuxt/test-utils": "3.19.2",
-    "@nuxt/ui": "4.0.0",
-    "@unhead/vue": "^2.0.17",
-    "better-sqlite3": "^12.4.1",
-    "eslint": "^9.36.0",
-    "nuxt": "^4.1.2",
-    "typescript": "^5.9.2",
-    "vue": "^3.5.21",
-    "vue-router": "^4.5.1"
+    "flowbite": "^2.3.0",
+    "flowbite-vue": "^0.3.0",
+    "nuxt": "^3.12.0"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.21",
-    "flowbite": "^3.1.2",
-    "flowbite-vue": "^0.2.1",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.13"
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.10"
   }
 }

--- a/plugins/flowbite.client.ts
+++ b/plugins/flowbite.client.ts
@@ -1,0 +1,5 @@
+import { FlowbiteVue } from 'flowbite-vue'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(FlowbiteVue)
+})

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,42 @@
+Tu es un générateur de dépôt. Crée UNIQUEMENT les fichiers suivants, sans rien d’autre.
+Respecte scrupuleusement le FORMAT DE SORTIE demandé.
+
+=== /! FORMAT DE SORTIE /! ===
+Pour CHAQUE fichier : 
+=== ./chemin/vers/fichier ===
+<contenu>
+
+=== FICHIERS À PRODUIRE (ÉTAPE 1) ===
+- ./package.json
+- ./nuxt.config.ts
+- ./tailwind.config.js
+- ./postcss.config.js
+- ./assets/css/tailwind.css
+- ./app.vue  (ou ./layouts/default.vue — choisis UNE approche cohérente)
+- ./plugins/flowbite.client.ts
+- ./prompt.md  (copie exacte du prompt utilisateur fourni à l’étape finale)
+
+=== CONTRAINTES GLOBALES ===
+- Node >= 18.17. Versions exactes dans package.json :
+  "nuxt":"^3.12.0", "tailwindcss":"^3.4.10", "flowbite":"^2.3.0", "flowbite-vue":"^0.3.0", "postcss":"^8.4.35", "autoprefixer":"^10.4.19"
+- nuxt.config.ts : 
+  export default defineNuxtConfig({
+    ssr: true,
+    build: { transpile: ['flowbite-vue'] },
+    vite: { ssr: { noExternal: ['flowbite-vue'] } }
+  })
+- tailwind.config.js : globs content EXACTS :
+  ['./app.vue','./error.vue','./app.config.ts',
+   './components/**/*.{vue,js,ts}','./layouts/**/*.{vue,js,ts}',
+   './pages/**/*.{vue,js,ts}','./plugins/**/*.{js,ts}','./server/**/*.{js,ts}',
+   './node_modules/flowbite/**/*.{js,vue,ts}','./node_modules/flowbite-vue/**/*.{js,vue,ts}']
+- assets/css/tailwind.css : 
+  @tailwind base;
+  @tailwind components;
+  @tailwind utilities;
+- app.vue (ou layout choisi) :
+  - Injecter via SSR un <style id="tenant-tokens"> (placeholder vide pour l’instant) DANS LE HEAD pour éviter le FOUC.
+  - useHead avec htmlAttrs { 'data-tenant': 'acme', 'data-theme': undefined } comme valeurs par défaut temporaires (seront remplacées à l’étape 2).
+- plugins/flowbite.client.ts : enregistrer flowbite-vue.
+
+N’AJOUTE AUCUN AUTRE FICHIER À CETTE ÉTAPE.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,20 @@
+const flowbitePlugin = require('flowbite/plugin')
+
+module.exports = {
+  content: [
+    './app.vue',
+    './error.vue',
+    './app.config.ts',
+    './components/**/*.{vue,js,ts}',
+    './layouts/**/*.{vue,js,ts}',
+    './pages/**/*.{vue,js,ts}',
+    './plugins/**/*.{js,ts}',
+    './server/**/*.{js,ts}',
+    './node_modules/flowbite/**/*.{js,vue,ts}',
+    './node_modules/flowbite-vue/**/*.{js,vue,ts}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: [flowbitePlugin]
+}


### PR DESCRIPTION
## Summary
- configure Nuxt to load Tailwind CSS and transpile Flowbite Vue components
- add Tailwind, PostCSS, and Flowbite setup files including base CSS entrypoint
- inject default SSR head attributes and register the Flowbite Vue plugin

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5749ea638832f9f04971c4a378cc2