### PR TITLE
Add tenant-aware theming support

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -5,15 +5,38 @@
 </template>
 
 <script setup lang="ts">
+let tenantId: string = 'acme'
+let theme: string | undefined = 'light'
+let css = ''
+
+if (process.server) {
+  const event = useRequestEvent()
+  const [{ DEFAULT_TENANT }, { loadTokens, tokensToCssVars }] = await Promise.all([
+    import('~/server/middleware/tenant'),
+    import('~/server/utils/theme')
+  ])
+
+  tenantId = (event?.context.tenantId as string | undefined) ?? DEFAULT_TENANT
+  const tokens = await loadTokens(tenantId)
+  theme = (tokens.theme as string | undefined) ?? 'light'
+  css = tokensToCssVars(tokens)
+} else if (process.client) {
+  const docEl = document.documentElement
+  tenantId = docEl.getAttribute('data-tenant') ?? tenantId
+  theme = docEl.getAttribute('data-theme') ?? theme
+  const existingStyle = document.getElementById('tenant-tokens')
+  css = existingStyle?.textContent ?? css
+}
+
 useHead({
   htmlAttrs: {
-    'data-tenant': 'acme',
-    'data-theme': undefined
+    'data-tenant': tenantId,
+    'data-theme': theme
   },
   style: [
     {
       id: 'tenant-tokens',
-      children: ''
+      children: css
     }
   ]
 })

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "demo-poc",
+  "ssr": true,
+  "cache": {
+    "html": false
+  },
+  "seo": {
+    "canonical": true,
+    "hreflang": true
+  }
+}

--- a/server/api/theme.get.ts
+++ b/server/api/theme.get.ts
@@ -1,0 +1,11 @@
+import { defineEventHandler } from 'h3'
+
+import { DEFAULT_TENANT } from '../middleware/tenant'
+import { loadTokens } from '../utils/theme'
+
+export default defineEventHandler(async (event) => {
+  const tenantId = (event.context.tenantId as string | undefined) ?? DEFAULT_TENANT
+  const tokens = await loadTokens(tenantId)
+
+  return tokens
+})

--- a/server/middleware/tenant.ts
+++ b/server/middleware/tenant.ts
@@ -1,0 +1,49 @@
+import { defineEventHandler, getQuery } from 'h3'
+
+export const SUPPORTED_TENANTS = ['acme', 'beta', 'gamma'] as const
+export const DEFAULT_TENANT = 'acme'
+
+type TenantId = (typeof SUPPORTED_TENANTS)[number]
+
+function resolveTenantFromHost(hostHeader?: string | string[]): TenantId | undefined {
+  if (!hostHeader) {
+    return undefined
+  }
+
+  const hostValue = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader
+  const hostname = hostValue.split(':')[0]?.toLowerCase() ?? ''
+  const potentialTenant = hostname.split('.')[0]
+
+  if (SUPPORTED_TENANTS.includes(potentialTenant as TenantId)) {
+    return potentialTenant as TenantId
+  }
+
+  return undefined
+}
+
+function isValidTenant(candidate?: string | string[]): candidate is TenantId {
+  if (!candidate || Array.isArray(candidate)) {
+    return false
+  }
+
+  return SUPPORTED_TENANTS.includes(candidate.toLowerCase() as TenantId)
+}
+
+export default defineEventHandler((event) => {
+  const headers = event.node.req.headers
+  const hostHeader = headers['x-forwarded-host'] ?? headers.host
+  let tenantId = resolveTenantFromHost(hostHeader) ?? DEFAULT_TENANT
+
+  const query = getQuery(event)
+  const requestedTenant = typeof query.tenant === 'string' ? query.tenant.toLowerCase() : undefined
+
+  if (
+    requestedTenant &&
+    process.env.NODE_ENV !== 'production' &&
+    isValidTenant(requestedTenant)
+  ) {
+    tenantId = requestedTenant as TenantId
+  }
+
+  event.context.tenantId = tenantId
+})

--- a/server/utils/theme.ts
+++ b/server/utils/theme.ts
@@ -1,0 +1,63 @@
+import { promises as fs } from 'node:fs'
+import { join } from 'node:path'
+
+const TOKENS_DIR = join(process.cwd(), 'tokens')
+
+export type TenantTokens = Record<string, string | number | boolean | null>
+
+export async function loadTokens(tenantId: string): Promise<TenantTokens> {
+  const filePath = join(TOKENS_DIR, `${tenantId}.tokens.json`)
+  const raw = await fs.readFile(filePath, 'utf8')
+  return JSON.parse(raw) as TenantTokens
+}
+
+const toString = (value: string | number | boolean | null | undefined): string => {
+  if (value === undefined || value === null) {
+    return ''
+  }
+
+  return String(value)
+}
+
+export function tokensToCssVars(tokens: TenantTokens): string {
+  const primary = toString(tokens['color.primary'])
+  const primaryContrast = toString(tokens['color.primary-contrast'])
+  const background = toString(tokens['color.bg'])
+  const text = toString(tokens['color.text'])
+  const radiusMd = toString(tokens['radius.md'])
+  const space2 = toString(tokens['space.2'])
+  const space4 = toString(tokens['space.4'])
+  const fontSans = toString(tokens['font.family.sans'])
+
+  const cssLines = [
+    ':root {',
+    `  --color-primary: ${primary};`,
+    `  --color-primary-contrast: ${primaryContrast};`,
+    `  --color-bg: ${background};`,
+    `  --color-text: ${text};`,
+    `  --radius-md: ${radiusMd};`,
+    `  --space-2: ${space2};`,
+    `  --space-4: ${space4};`,
+    `  --font-sans: ${fontSans};`,
+    '}'
+  ]
+
+  const blocks = [cssLines.join('\n')]
+
+  const darkEnabled = Boolean(tokens['dark.enabled'])
+  if (darkEnabled && (background || text)) {
+    const darkBackground = text || background
+    const darkText = background || text
+
+    blocks.push(
+      [
+        ':root[data-theme="dark"] {',
+        `  --color-bg: ${darkBackground};`,
+        `  --color-text: ${darkText};`,
+        '}'
+      ].join('\n')
+    )
+  }
+
+  return blocks.join('\n')
+}

--- a/tokens/acme.tokens.json
+++ b/tokens/acme.tokens.json
@@ -1,0 +1,11 @@
+{
+  "color.primary": "#0F6FFF",
+  "color.primary-contrast": "#FFFFFF",
+  "color.bg": "#FFFFFF",
+  "color.text": "#101828",
+  "radius.md": "10px",
+  "font.family.sans": "Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+  "space.2": "0.5rem",
+  "space.4": "1rem",
+  "dark.enabled": true
+}

--- a/tokens/beta.tokens.json
+++ b/tokens/beta.tokens.json
@@ -1,0 +1,11 @@
+{
+  "color.primary": "#A855F7",
+  "color.primary-contrast": "#0B0B0B",
+  "color.bg": "#0B0B0B",
+  "color.text": "#EDEDED",
+  "radius.md": "6px",
+  "font.family.sans": "Manrope, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+  "space.2": "0.5rem",
+  "space.4": "1rem",
+  "dark.enabled": false
+}

--- a/tokens/gamma.tokens.json
+++ b/tokens/gamma.tokens.json
@@ -1,0 +1,11 @@
+{
+  "color.primary": "#16A34A",
+  "color.primary-contrast": "#FFFFFF",
+  "color.bg": "#F0FDF4",
+  "color.text": "#064E3B",
+  "radius.md": "12px",
+  "font.family.sans": "Poppins, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+  "space.2": "0.5rem",
+  "space.4": "1rem",
+  "dark.enabled": false
+}


### PR DESCRIPTION
## Summary
- add tenant middleware to resolve current tenant from host or dev override
- expose token loader utilities and API to serve active theme tokens with flattened token keys and dark-mode support flag
- preload tenant CSS variables and attributes during SSR with tenant-specific token files
- include project manifest metadata for cache and SEO flags
- update tenant token JSON definitions to the agreed key/value format

## Testing
- `pnpm build` *(fails: missing app/assets/css/tailwind.css in project template)*

------
https://chatgpt.com/codex/tasks/task_e_68d5764d4fe0832fb717f98df27889bd