### PR TITLE
Add token-themed pages and Flowbite demo

### DIFF
--- a/components/DSButton.vue
+++ b/components/DSButton.vue
@@ -1,0 +1,13 @@
+<template>
+  <button
+    type="button"
+    class="inline-flex items-center justify-center bg-primary text-[color:var(--color-primary-contrast)] rounded-md px-[var(--space-4)] py-[var(--space-2)] font-sans"
+    @click="$emit('click', $event)"
+  >
+    <slot />
+  </button>
+</template>
+
+<script setup lang="ts">
+defineEmits<{ (event: 'click', payload: MouseEvent): void }>()
+</script>

--- a/components/DSCard.vue
+++ b/components/DSCard.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="bg-bg text-text rounded-md p-[var(--space-4)] border border-[color:var(--color-primary)] font-sans">
+    <slot />
+  </div>
+</template>

--- a/error.vue
+++ b/error.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="flex min-h-screen flex-col items-center justify-center bg-bg px-[var(--space-4)] py-[var(--space-4)] text-text font-sans">
+    <div class="max-w-lg space-y-[var(--space-4)] text-center">
+      <h1 class="text-5xl font-bold">404</h1>
+      <p class="text-lg">La page que vous recherchez n'existe pas ou a été déplacée.</p>
+      <NuxtLink class="inline-flex justify-center" to="/">
+        <DSButton>Retour à l'accueil</DSButton>
+      </NuxtLink>
+      <p>
+        Besoin d'assistance ? Contactez-nous et nous vous aiderons à retrouver votre chemin.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ error: { statusCode?: number } }>()
+
+useHead({
+  title: props.error?.statusCode === 404 ? 'Page non trouvée · Tokens Demo' : 'Erreur · Tokens Demo'
+})
+</script>

--- a/pages/en.vue
+++ b/pages/en.vue
@@ -1,0 +1,34 @@
+<template>
+  <main class="min-h-screen bg-bg px-[var(--space-4)] py-[var(--space-4)] text-text font-sans">
+    <article class="mx-auto max-w-3xl space-y-[var(--space-4)]">
+      <header>
+        <h1 class="text-3xl font-bold">Welcome to the English version</h1>
+        <p class="mt-[var(--space-2)]">Explore how design tokens create a cohesive multilingual experience.</p>
+      </header>
+      <p>
+        This localized English page reuses the same CSS variables as the main experience to guarantee consistency.
+      </p>
+      <NuxtLink class="inline-flex" to="/fr">
+        <DSButton>Passer en français</DSButton>
+      </NuxtLink>
+    </article>
+  </main>
+</template>
+
+<script setup lang="ts">
+useHead({
+  title: 'English version · Tokens Demo',
+  meta: [
+    {
+      name: 'description',
+      content: 'English page showcasing the design token usage.'
+    }
+  ],
+  link: [
+    { rel: 'canonical', href: 'https://example.com/en' },
+    { rel: 'alternate', hreflang: 'fr', href: 'https://example.com/fr' },
+    { rel: 'alternate', hreflang: 'en', href: 'https://example.com/en' },
+    { rel: 'alternate', hreflang: 'x-default', href: 'https://example.com/' }
+  ]
+})
+</script>

--- a/pages/flowbite.vue
+++ b/pages/flowbite.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="min-h-screen bg-bg text-text font-sans">
+    <header class="border-b border-[color:var(--color-primary)] bg-bg px-[var(--space-4)] py-[var(--space-2)]">
+      <h1 class="text-3xl font-bold">Flowbite &amp; Tokens</h1>
+      <p class="text-sm">Intégration des composants Flowbite-Vue avec les variables de design tokens.</p>
+    </header>
+
+    <main class="mx-auto flex max-w-5xl flex-col gap-[var(--space-4)] px-[var(--space-4)] py-[var(--space-4)]">
+      <section class="space-y-[var(--space-2)]">
+        <FlowButton class="bg-primary text-[color:var(--color-primary-contrast)] rounded-md px-[var(--space-4)] py-[var(--space-2)] font-semibold" @click="isModalOpen = true">
+          Ouvrir la modale
+        </FlowButton>
+
+        <FlowAlert class="bg-primary/10 text-text border border-[color:var(--color-primary)]">
+          Les composants Flowbite peuvent être harmonisés avec les tokens grâce aux classes Tailwind personnalisées.
+        </FlowAlert>
+      </section>
+
+      <section>
+        <FlowTabs class="text-text">
+          <FlowTab title="Présentation">
+            <p class="p-[var(--space-4)]">
+              Utilisez les onglets Flowbite pour organiser le contenu, tout en conservant la typographie <span class="font-semibold">font-sans</span>.
+            </p>
+          </FlowTab>
+          <FlowTab title="Actions">
+            <div class="flex gap-[var(--space-4)] p-[var(--space-4)]">
+              <FlowButton class="bg-primary text-[color:var(--color-primary-contrast)] rounded-md px-[var(--space-4)] py-[var(--space-2)]">
+                Action primaire
+              </FlowButton>
+              <FlowButton class="bg-bg text-text border border-[color:var(--color-primary)] rounded-md px-[var(--space-4)] py-[var(--space-2)]">
+                Action secondaire
+              </FlowButton>
+            </div>
+          </FlowTab>
+        </FlowTabs>
+      </section>
+
+      <section class="rounded-md border border-[color:var(--color-primary)] bg-bg p-[var(--space-4)]">
+        <header class="mb-[var(--space-2)] flex items-center justify-between">
+          <h2 class="text-xl font-semibold">Token Debug Panel</h2>
+          <div v-if="tokens?.dark?.enabled" class="flex items-center gap-[var(--space-2)]">
+            <label for="dark-toggle" class="text-sm">Thème sombre</label>
+            <input id="dark-toggle" v-model="isDark" class="h-4 w-4" type="checkbox" />
+          </div>
+        </header>
+        <div v-if="tokenEntries.length" class="grid gap-[var(--space-2)] md:grid-cols-2">
+          <div v-for="([key, value], index) in tokenEntries" :key="`${key}-${index}`" class="rounded-md border border-[color:var(--color-primary)] bg-bg p-[var(--space-2)]">
+            <p class="text-sm font-semibold">{{ key }}</p>
+            <p class="text-xs break-words">{{ formatValue(value) }}</p>
+          </div>
+        </div>
+        <p v-else class="text-sm">Chargement des tokens...</p>
+      </section>
+    </main>
+
+    <FlowModal v-model:show="isModalOpen" class="text-text">
+      <template #header>
+        <h3 class="text-lg font-semibold">Modale pilotée par tokens</h3>
+      </template>
+      <p class="py-[var(--space-2)]">
+        Les couleurs et espacements de cette modale sont contrôlés via les variables CSS définies par les design tokens.
+      </p>
+      <template #footer>
+        <div class="flex justify-end gap-[var(--space-2)]">
+          <FlowButton class="bg-bg text-text border border-[color:var(--color-primary)] rounded-md px-[var(--space-4)] py-[var(--space-2)]" @click="isModalOpen = false">
+            Fermer
+          </FlowButton>
+        </div>
+      </template>
+    </FlowModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { Alert as FlowAlert, Button as FlowButton, Modal as FlowModal, Tab as FlowTab, Tabs as FlowTabs } from 'flowbite-vue'
+
+const isModalOpen = ref(false)
+const isDark = ref(false)
+
+const { data: tokens } = await useFetch('/api/theme')
+
+const tokenEntries = computed(() => {
+  if (!tokens.value || typeof tokens.value !== 'object') {
+    return [] as Array<[string, unknown]>
+  }
+  return Object.entries(tokens.value as Record<string, unknown>)
+})
+
+const formatValue = (value: unknown) => {
+  if (typeof value === 'object' && value !== null) {
+    return JSON.stringify(value)
+  }
+  return String(value)
+}
+
+onMounted(() => {
+  isDark.value = document.documentElement.dataset.theme === 'dark'
+})
+
+watch(isDark, (value) => {
+  if (value) {
+    document.documentElement.dataset.theme = 'dark'
+  } else {
+    delete document.documentElement.dataset.theme
+  }
+})
+
+useHead({
+  title: 'Flowbite · Tokens Demo',
+  meta: [
+    {
+      name: 'description',
+      content: 'Exemples Flowbite-Vue intégrés aux design tokens et panneau de débogage.'
+    }
+  ]
+})
+</script>

--- a/pages/fr.vue
+++ b/pages/fr.vue
@@ -1,0 +1,34 @@
+<template>
+  <main class="min-h-screen bg-bg px-[var(--space-4)] py-[var(--space-4)] text-text font-sans">
+    <article class="mx-auto max-w-3xl space-y-[var(--space-4)]">
+      <header>
+        <h1 class="text-3xl font-bold">Bienvenue sur la version française</h1>
+        <p class="mt-[var(--space-2)]">Découvrez comment les design tokens harmonisent l'expérience utilisateur.</p>
+      </header>
+      <p>
+        Cette page démontre une version localisée en français utilisant les mêmes variables CSS que la version principale.
+      </p>
+      <NuxtLink class="inline-flex" to="/en">
+        <DSButton>Switch to English</DSButton>
+      </NuxtLink>
+    </article>
+  </main>
+</template>
+
+<script setup lang="ts">
+useHead({
+  title: 'Version française · Tokens Demo',
+  meta: [
+    {
+      name: 'description',
+      content: 'Page française démontrant les design tokens.'
+    }
+  ],
+  link: [
+    { rel: 'canonical', href: 'https://example.com/fr' },
+    { rel: 'alternate', hreflang: 'fr', href: 'https://example.com/fr' },
+    { rel: 'alternate', hreflang: 'en', href: 'https://example.com/en' },
+    { rel: 'alternate', hreflang: 'x-default', href: 'https://example.com/' }
+  ]
+})
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="min-h-screen bg-bg text-text font-sans">
+    <header class="border-b border-[color:var(--color-primary)] bg-bg">
+      <nav class="mx-auto flex max-w-5xl items-center justify-between px-[var(--space-4)] py-[var(--space-2)]">
+        <span class="text-lg font-semibold">Token Demo</span>
+        <ul class="flex gap-[var(--space-4)]">
+          <li><NuxtLink class="hover:underline" to="/fr">FR</NuxtLink></li>
+          <li><NuxtLink class="hover:underline" to="/en">EN</NuxtLink></li>
+          <li><NuxtLink class="hover:underline" to="/flowbite">Flowbite</NuxtLink></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="mx-auto flex max-w-5xl flex-col gap-[var(--space-4)] px-[var(--space-4)] py-[var(--space-4)]" id="main-content">
+      <section class="space-y-[var(--space-2)]">
+        <h1 class="text-3xl font-bold">Design Token Playground</h1>
+        <p>
+          Cette page utilise <span class="font-semibold">text-text</span> et <span class="font-semibold">bg-bg</span> pour démontrer l'application des
+          jetons de design dans une interface Nuxt.
+        </p>
+        <img
+          alt="Gradient placeholder"
+          loading="lazy"
+          class="w-full max-w-sm rounded-md border border-[color:var(--color-primary)]"
+          src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMzAwJyBoZWlnaHQ9JTk1JyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxsaW5lYXJHcmFkaWVudCBpZD0nZycgeDE9JzAlJyB5MT0nMCUnIHgyPScxMDAlJyB5Mj0nMTAwJSc+PHN0b3Agb2Zmc2V0PScwJScgc3RvcC1jb2xvcj0nI2ZmZicvPjxzdG9wIG9mZnNldD0nMTAwJScgc3RvcC1jb2xvcj0nI2QwZCcvPjwvbGluZWFyR3JhZGllbnQ+PHJlY3Qgd2lkdGg9JzMwMCcgaGVpZ2h0PSc5NScgZmlsbD0ndXJsKCNnKScvPjwvc3ZnPg=="
+        />
+      </section>
+
+      <section class="grid gap-[var(--space-4)] md:grid-cols-2">
+        <DSCard>
+          <h2 class="text-xl font-semibold">Carte stylisée</h2>
+          <p>
+            Le composant DSCard applique automatiquement les jetons <code>bg-bg</code>, <code>text-text</code> et
+            <code>color-primary</code>.
+          </p>
+          <DSButton class="mt-[var(--space-4)]" @click="onPrimaryAction">Action principale</DSButton>
+        </DSCard>
+        <DSCard>
+          <h2 class="text-xl font-semibold">Composants Nuxt</h2>
+          <p>
+            Combinez les composants personnalisés avec NuxtLink pour créer des expériences localisées.
+          </p>
+          <NuxtLink class="mt-[var(--space-4)] inline-flex" to="/flowbite">
+            <DSButton>Voir Flowbite</DSButton>
+          </NuxtLink>
+        </DSCard>
+      </section>
+    </main>
+
+    <footer class="mt-auto border-t border-[color:var(--color-primary)] bg-bg">
+      <div class="mx-auto max-w-5xl px-[var(--space-4)] py-[var(--space-2)]">
+        &copy; {{ new Date().getFullYear() }} Tokens Demo
+      </div>
+    </footer>
+  </div>
+</template>
+
+<script setup lang="ts">
+const onPrimaryAction = () => {
+  // Placeholder action for demonstration purposes.
+}
+
+useHead({
+  title: 'Accueil · Tokens Demo',
+  meta: [
+    {
+      name: 'description',
+      content: 'Page de démonstration des design tokens avec composants personnalisés.'
+    }
+  ]
+})
+</script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,23 @@ module.exports = {
     './node_modules/flowbite-vue/**/*.{js,vue,ts}'
   ],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        primary: 'var(--color-primary)',
+        text: 'var(--color-text)',
+        bg: 'var(--color-bg)'
+      },
+      borderRadius: {
+        md: 'var(--radius-md)'
+      },
+      spacing: {
+        2: 'var(--space-2)',
+        4: 'var(--space-4)'
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)']
+      }
+    }
   },
   plugins: [flowbitePlugin]
 }


### PR DESCRIPTION
## Summary
- add DSButton and DSCard components wired to design token utility classes
- create index, Flowbite, and localized FR/EN pages demonstrating tokens and Flowbite integrations
- implement token-aware 404 page and extend Tailwind theme with token-based values

## Testing
- `pnpm install` *(fails: No matching version found for flowbite-vue@^0.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d57931a988832fa05c422c15f8654b