### PR TITLE
Fix Tailwind integration and Nuxt config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,22 @@
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectDir = dirname(fileURLToPath(import.meta.url))
+
 export default defineNuxtConfig({
+  compatibilityDate: '2025-09-25',
   ssr: true,
+  alias: {
+    '@': projectDir,
+    '~': projectDir
+  },
   css: ['~/assets/css/tailwind.css'],
+  postcss: {
+    plugins: {
+      '@tailwindcss/postcss': {},
+      autoprefixer: {}
+    }
+  },
   build: { transpile: ['flowbite-vue'] },
   vite: { ssr: { noExternal: ['flowbite-vue'] } }
 })

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "nuxt": "^4.1.2"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.13",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.35",
     "tailwindcss": "^4.1.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.22)(better-sqlite3@12.4.1)(db0@0.3.2(better-sqlite3@12.4.1))(eslint@9.36.0(jiti@2.6.0))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.2)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.7(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
     devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.1.13
+        version: 4.1.13
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.21(postcss@8.5.6)

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {}
-  }
-}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
-const flowbitePlugin = require('flowbite/plugin')
+import flowbitePlugin from 'flowbite/plugin'
 
-module.exports = {
+export default {
   content: [
     './app.vue',
     './error.vue',


### PR DESCRIPTION
## Summary
- configure Nuxt to set the compatibility date, register project aliases, and inline the Tailwind/PostCSS setup
- add the @tailwindcss/postcss dev dependency and remove the legacy postcss.config.js file to silence Nuxt warnings
- switch the Tailwind configuration to ESM so Flowbite's plugin can be imported without require()

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5a2ee44c4832f911de4ba739ade03