### PR TITLE
Fix Tailwind and Flowbite integration for Nuxt 4

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,19 @@
 export default defineNuxtConfig({
+  srcDir: '.',
   ssr: true,
   css: ['~/assets/css/tailwind.css'],
-  build: { transpile: ['flowbite-vue'] },
-  vite: { ssr: { noExternal: ['flowbite-vue'] } }
+  build: {
+    transpile: ['flowbite-vue']
+  },
+  postcss: {
+    plugins: {
+      '@tailwindcss/postcss': {},
+      autoprefixer: {}
+    }
+  },
+  vite: {
+    ssr: {
+      noExternal: ['flowbite-vue']
+    }
+  }
 })

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "nuxt": "^4.1.2"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.13",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.35",
     "tailwindcss": "^4.1.13"

--- a/pages/flowbite.vue
+++ b/pages/flowbite.vue
@@ -7,33 +7,33 @@
 
     <main class="mx-auto flex max-w-5xl flex-col gap-[var(--space-4)] px-[var(--space-4)] py-[var(--space-4)]">
       <section class="space-y-[var(--space-2)]">
-        <FlowButton class="bg-primary text-[color:var(--color-primary-contrast)] rounded-md px-[var(--space-4)] py-[var(--space-2)] font-semibold" @click="isModalOpen = true">
+        <FwbButton class="bg-primary text-[color:var(--color-primary-contrast)] rounded-md px-[var(--space-4)] py-[var(--space-2)] font-semibold" @click="isModalOpen = true">
           Ouvrir la modale
-        </FlowButton>
+        </FwbButton>
 
-        <FlowAlert class="bg-primary/10 text-text border border-[color:var(--color-primary)]">
+        <FwbAlert class="bg-primary/10 text-text border border-[color:var(--color-primary)]">
           Les composants Flowbite peuvent être harmonisés avec les tokens grâce aux classes Tailwind personnalisées.
-        </FlowAlert>
+        </FwbAlert>
       </section>
 
       <section>
-        <FlowTabs class="text-text">
-          <FlowTab title="Présentation">
+        <FwbTabs class="text-text">
+          <FwbTab title="Présentation">
             <p class="p-[var(--space-4)]">
               Utilisez les onglets Flowbite pour organiser le contenu, tout en conservant la typographie <span class="font-semibold">font-sans</span>.
             </p>
-          </FlowTab>
-          <FlowTab title="Actions">
+          </FwbTab>
+          <FwbTab title="Actions">
             <div class="flex gap-[var(--space-4)] p-[var(--space-4)]">
-              <FlowButton class="bg-primary text-[color:var(--color-primary-contrast)] rounded-md px-[var(--space-4)] py-[var(--space-2)]">
+              <FwbButton class="bg-primary text-[color:var(--color-primary-contrast)] rounded-md px-[var(--space-4)] py-[var(--space-2)]">
                 Action primaire
-              </FlowButton>
-              <FlowButton class="bg-bg text-text border border-[color:var(--color-primary)] rounded-md px-[var(--space-4)] py-[var(--space-2)]">
+              </FwbButton>
+              <FwbButton class="bg-bg text-text border border-[color:var(--color-primary)] rounded-md px-[var(--space-4)] py-[var(--space-2)]">
                 Action secondaire
-              </FlowButton>
+              </FwbButton>
             </div>
-          </FlowTab>
-        </FlowTabs>
+          </FwbTab>
+        </FwbTabs>
       </section>
 
       <section class="rounded-md border border-[color:var(--color-primary)] bg-bg p-[var(--space-4)]">
@@ -54,7 +54,7 @@
       </section>
     </main>
 
-    <FlowModal v-model:show="isModalOpen" class="text-text">
+    <FwbModal v-model:show="isModalOpen" class="text-text">
       <template #header>
         <h3 class="text-lg font-semibold">Modale pilotée par tokens</h3>
       </template>
@@ -63,18 +63,18 @@
       </p>
       <template #footer>
         <div class="flex justify-end gap-[var(--space-2)]">
-          <FlowButton class="bg-bg text-text border border-[color:var(--color-primary)] rounded-md px-[var(--space-4)] py-[var(--space-2)]" @click="isModalOpen = false">
+          <FwbButton class="bg-bg text-text border border-[color:var(--color-primary)] rounded-md px-[var(--space-4)] py-[var(--space-2)]" @click="isModalOpen = false">
             Fermer
-          </FlowButton>
+          </FwbButton>
         </div>
       </template>
-    </FlowModal>
+    </FwbModal>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { Alert as FlowAlert, Button as FlowButton, Modal as FlowModal, Tab as FlowTab, Tabs as FlowTabs } from 'flowbite-vue'
+import { FwbAlert, FwbButton, FwbModal, FwbTab, FwbTabs } from 'flowbite-vue'
 
 const isModalOpen = ref(false)
 const isDark = ref(false)

--- a/plugins/flowbite.client.ts
+++ b/plugins/flowbite.client.ts
@@ -1,5 +1,0 @@
-import { FlowbiteVue } from 'flowbite-vue'
-
-export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(FlowbiteVue)
-})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.22)(better-sqlite3@12.4.1)(db0@0.3.2(better-sqlite3@12.4.1))(eslint@9.36.0(jiti@2.6.0))(ioredis@5.8.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.2)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.7(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
     devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.1.13
+        version: 4.1.13
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.21(postcss@8.5.6)

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {}
-  }
-}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
-const flowbitePlugin = require('flowbite/plugin')
+import flowbitePlugin from 'flowbite/plugin'
 
-module.exports = {
+export default {
   content: [
     './app.vue',
     './error.vue',


### PR DESCRIPTION
## Summary
- configure Nuxt to resolve the root app directory, load Tailwind through postcss options, and depend on @tailwindcss/postcss
- convert the Tailwind config to ESM and update the Flowbite showcase page to use the new Fwb component names directly
- remove the legacy Flowbite plugin and standalone postcss.config.js that conflicted with Nuxt 4

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a2ee44c4832f911de4ba739ade03